### PR TITLE
feat: add symlink of logrotate to cron.hourly

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -73,6 +73,16 @@
     owner: root
     group: root
     mode: 0644
+  tags: logrotate
+
+- name: "Create logrotate symlink to cron.hourly"
+  file:
+    src: /etc/cron.daily/logrotate
+    dest: /etc/cron.hourly/logrotate
+    owner: root
+    group: root
+    state: link
+  tags: logrotate
 
 - name: Create kong config file
   template:


### PR DESCRIPTION
Create symlink to allow cron.hourly in case it's defined on Kong's logrotate.

![image](https://user-images.githubusercontent.com/19431474/58500411-7ca7fd00-8158-11e9-9fdc-ce38cfb51134.png)
