### PR TITLE
feat/config: supporting log config params on template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,11 @@ kong_server_real_ip_header:     "X-Real-IP"
 kong_server_real_ip_recursive:  "off"
 kong_client_body_buffer_size:   8k
 
+kong_proxy_access_log: logs/access.log
+kong_proxy_error_log: logs/error.log
+kong_admin_access_log: logs/admin_access.log
+kong_admin_error_log: logs/error.log
+
 ##------------------
 ## DATASTORE
 ##------------------

--- a/templates/kong.conf.j2
+++ b/templates/kong.conf.j2
@@ -36,29 +36,26 @@ log_level = {{ kong_log_level }}
 # Note: See http://nginx.org/en/docs/ngx_core_module.html#error_log for a list
 # of accepted values.
 
-{% kong_proxy_access_log is defined %}
-proxy_access_log = {{ kong_proxy_access_log }}
-{% else %}
-#proxy_access_log = logs/access.log       # Path for proxy port request access
+proxy_access_log = {{ kong_proxy_access_log }}       # Path for proxy port request access
                                           # logs. Set this value to `off` to
                                           # disable logging proxy requests.
                                           # If this value is a relative path, it
                                           # will be placed under the `prefix`
                                           # location.
 
-#proxy_error_log = logs/error.log         # Path for proxy port request error
+proxy_error_log = {{ kong_proxy_error_log }}         # Path for proxy port request error
                                           # logs. Granularity of these logs is
                                           # adjusted by the `log_level`
                                           # directive.
 
-#admin_access_log = logs/admin_access.log # Path for Admin API request access
+admin_access_log = {{ kong_admin_access_log }}  # Path for Admin API request access
                                           # logs. Set this value to `off` to
                                           # disable logging Admin API requests.
                                           # If this value is a relative path, it
                                           # will be placed under the `prefix`
                                           # location.
 
-#admin_error_log = logs/error.log         # Path for Admin API request error
+admin_error_log = {{ kong_admin_access_log }}         # Path for Admin API request error
                                           # logs. Granularity of these logs is
                                           # adjusted by the `log_level`
                                           # directive.

--- a/templates/kong.conf.j2
+++ b/templates/kong.conf.j2
@@ -36,6 +36,9 @@ log_level = {{ kong_log_level }}
 # Note: See http://nginx.org/en/docs/ngx_core_module.html#error_log for a list
 # of accepted values.
 
+{% kong_proxy_access_log is defined %}
+proxy_access_log = {{ kong_proxy_access_log }}
+{% else %}
 #proxy_access_log = logs/access.log       # Path for proxy port request access
                                           # logs. Set this value to `off` to
                                           # disable logging proxy requests.


### PR DESCRIPTION
Supporting options to setup main conf file:
- kong_proxy_access_log: logs/access.log
- kong_proxy_error_log: logs/error.log
- kong_admin_access_log: logs/admin_access.log
- kong_admin_error_log: logs/error.log