### PR TITLE
Fix/template: fix template typo

### DIFF
--- a/templates/plugin_obj.j2
+++ b/templates/plugin_obj.j2
@@ -15,6 +15,6 @@
 {% if plugin_obj.update({'route': {'id':plugin_route_id}}) %}{% endif %}
 {% endif %}
 {% if consumer.status|default(false) == 200 %}
-{% if plugin_obj.update({'consumer': {'id': consumer.json.id}) %}{% endif %}
+{% if plugin_obj.update({'consumer': {'id': consumer.json.id}}) %}{% endif %}
 {% endif %}
 {{ plugin_obj|to_nice_json }}


### PR DESCRIPTION
fix a typo on a template, there are two PRs open in upstream (https://github.com/wunzeco/ansible-kong/pull/33 and https://github.com/wunzeco/ansible-kong/pull/30) but they aren't merged